### PR TITLE
feat(LaunchPad): Save state of presets when switching

### DIFF
--- a/packages/launchpad-common/src/Preset.ts
+++ b/packages/launchpad-common/src/Preset.ts
@@ -74,8 +74,12 @@ export const makePresetTemplate = (
   }
 }
 
-type PresetTemplate = {
+export type PresetTemplate = {
   controls: ControlTemplate<ControlContext, ControlType>[]
+}
+
+export type PresetState = {
+  controlStates: any[]
 }
 
 export class Preset extends Component {
@@ -92,6 +96,18 @@ export class Preset extends Component {
     super.onMount()
     for (const control of this.controls) {
       control.mount()
+    }
+  }
+
+  set state(presetState: PresetState) {
+    for (const i in this.controls) {
+      this.controls[i].state = presetState.controlStates[i]
+    }
+  }
+
+  get state(): PresetState {
+    return {
+      controlStates: this.controls.map((c) => c.state),
     }
   }
 

--- a/packages/launchpad-common/src/controls/beatjump.ts
+++ b/packages/launchpad-common/src/controls/beatjump.ts
@@ -11,9 +11,10 @@ export type Type = {
     gridPosition: [number, number]
     jumps: readonly [number, number][]
     vertical?: boolean
+    bounce?: boolean
   }
   state: {
-    mode: boolean
+    bounce: boolean
     pressing: number | null
     diff: number
     set: number
@@ -23,7 +24,7 @@ export type Type = {
 
 const colors = ['green', 'red']
 
-const make: MakeDeckControlTemplate<Type> = ({ deck, gridPosition, jumps, vertical = false }) => {
+const make: MakeDeckControlTemplate<Type> = ({ deck, gridPosition, jumps, vertical = false, bounce = false }) => {
   const bindings: Type['bindings'] = {}
   const spec = jumps.flatMap((j) => [
     [j, -1],
@@ -37,7 +38,7 @@ const make: MakeDeckControlTemplate<Type> = ({ deck, gridPosition, jumps, vertic
         modes(
           mode,
           () => {
-            if (!state.mode) {
+            if (!state.bounce) {
               if (value) {
                 setValue(deck.beatjump, j[state.set] * d)
               }
@@ -64,7 +65,7 @@ const make: MakeDeckControlTemplate<Type> = ({ deck, gridPosition, jumps, vertic
           () => {
             if (value) {
               state.set = posMod(state.set + 1, 2)
-              const prefix = state.mode ? 'lo' : 'hi'
+              const prefix = state.bounce ? 'lo' : 'hi'
               for (let b = 0; b < spec.length; ++b) {
                 device.sendColor(bindings[b].control, device.colors[`${prefix}_${colors[state.set]}`])
               }
@@ -72,8 +73,8 @@ const make: MakeDeckControlTemplate<Type> = ({ deck, gridPosition, jumps, vertic
           },
           () => {
             if (value) {
-              state.mode = !state.mode
-              const prefix = state.mode ? 'lo' : 'hi'
+              state.bounce = !state.bounce
+              const prefix = state.bounce ? 'lo' : 'hi'
               for (let b = 0; b < spec.length; ++b) {
                 device.sendColor(bindings[b].control, device.colors[`${prefix}_${colors[state.set]}`])
               }
@@ -85,7 +86,7 @@ const make: MakeDeckControlTemplate<Type> = ({ deck, gridPosition, jumps, vertic
     (k: number) =>
     ({ bindings, state, context: { device } }: Control<Type>) =>
     () => {
-      const prefix = state.mode ? 'lo' : 'hi'
+      const prefix = state.bounce ? 'lo' : 'hi'
 
       device.sendColor(bindings[k].control, device.colors[`${prefix}_${colors[state.set]}`])
     }
@@ -106,7 +107,7 @@ const make: MakeDeckControlTemplate<Type> = ({ deck, gridPosition, jumps, vertic
   return {
     bindings,
     state: {
-      mode: false,
+      bounce: bounce,
       pressing: null,
       diff: 0,
       set: 0,

--- a/packages/launchpad-common/src/controls/loopjump.ts
+++ b/packages/launchpad-common/src/controls/loopjump.ts
@@ -14,9 +14,10 @@ export type Type = {
     gridPosition: [number, number]
     jumps: readonly [number, number][]
     vertical?: boolean
+    bounce?: boolean
   }
   state: {
-    mode: boolean
+    bounce: boolean
     pressing: number | null
     diff: number
     set: number
@@ -24,7 +25,7 @@ export type Type = {
   }
 }
 
-const make: MakeDeckControlTemplate<Type> = ({ gridPosition, deck, jumps, vertical = false }) => {
+const make: MakeDeckControlTemplate<Type> = ({ gridPosition, deck, jumps, vertical = false, bounce = false }) => {
   const bindings: Type['bindings'] = {}
   const onMidi =
     (k: number, j: [number, number], d: number) =>
@@ -33,7 +34,7 @@ const make: MakeDeckControlTemplate<Type> = ({ gridPosition, deck, jumps, vertic
         modes(
           mode,
           () => {
-            if (!state.mode) {
+            if (!state.bounce) {
               if (value) {
                 setValue(deck.loop_move, j[state.set] * d)
               }
@@ -61,7 +62,7 @@ const make: MakeDeckControlTemplate<Type> = ({ gridPosition, deck, jumps, vertic
           () => {
             if (value) {
               state.set = posMod(state.set + 1, 2)
-              const prefix = state.mode ? 'lo' : 'hi'
+              const prefix = state.bounce ? 'lo' : 'hi'
               for (let b = 0; b < spec.length; ++b) {
                 device.sendColor(bindings[b].control, device.colors[`${prefix}_${state.color[state.set]}`])
               }
@@ -69,8 +70,8 @@ const make: MakeDeckControlTemplate<Type> = ({ gridPosition, deck, jumps, vertic
           },
           () => {
             if (value) {
-              state.mode = !state.mode
-              const prefix = state.mode ? 'lo' : 'hi'
+              state.bounce = !state.bounce
+              const prefix = state.bounce ? 'lo' : 'hi'
               for (let b = 0; b < spec.length; ++b) {
                 device.sendColor(bindings[b].control, device.colors[`${prefix}_${state.color[state.set]}`])
               }
@@ -82,7 +83,7 @@ const make: MakeDeckControlTemplate<Type> = ({ gridPosition, deck, jumps, vertic
     (k: number) =>
     ({ context: { device }, bindings, state }: Control<Type>) =>
     () => {
-      const prefix = state.mode ? 'lo' : 'hi'
+      const prefix = state.bounce ? 'lo' : 'hi'
       device.sendColor(bindings[k].control, device.colors[`${prefix}_${state.color[state.set]}`])
     }
   const spec = jumps.flatMap((j) => [
@@ -106,7 +107,7 @@ const make: MakeDeckControlTemplate<Type> = ({ gridPosition, deck, jumps, vertic
   return {
     bindings,
     state: {
-      mode: false,
+      bounce: bounce,
       pressing: null,
       diff: 0,
       set: 0,


### PR DESCRIPTION
This PR adds preset state save/restore functionality to launchpad App. Main motivation is to enable recalling the set of loop and beatjumps after they were modified. Currently if user changes the set of loopjumps for a laid out preset, once the preset is removed by a layout update, its state is lost. This PR changes that.
Also renames `mode` to `bounce` for loopjump and beatjump controls and exposes them as parameter.